### PR TITLE
Update 720pdl.py

### DIFF
--- a/720pdl.py
+++ b/720pdl.py
@@ -17,6 +17,7 @@ from qbclient import Client
 
 
 def loadOrCreateCfgfile():
+    today = pendulum.now()  # Define today using Pendulum
     if os.path.isfile('720pier.ini.yml'):
         with open('720pier.ini.yml', "r") as ini:
             c = yaml.load(ini, Loader=BaseLoader)


### PR DESCRIPTION
Fix for this error:

```
Traceback (most recent call last):
  File "/root/720dl/720pdl.py", line 257, in <module>
    cfg = loadOrCreateCfgfile()
  File "/root/720dl/720pdl.py", line 32, in loadOrCreateCfgfile
    c['Default']['skipOlderThan'] = today.start_of("year").format("YYYY-MM-DD")
NameError: name 'today' is not defined
```